### PR TITLE
Fix multiple definitions linker error with GCC 10

### DIFF
--- a/src/indicator-printer-state-notifier.c
+++ b/src/indicator-printer-state-notifier.c
@@ -52,7 +52,7 @@ enum {
     NUM_PROPERTIES
 };
 
-GParamSpec *properties[NUM_PROPERTIES];
+static GParamSpec *properties[NUM_PROPERTIES];
 
 
 static void

--- a/src/indicator-printers-menu.c
+++ b/src/indicator-printers-menu.c
@@ -42,7 +42,7 @@ enum {
     NUM_PROPERTIES
 };
 
-GParamSpec *properties[NUM_PROPERTIES];
+static GParamSpec *properties[NUM_PROPERTIES];
 
 
 static void


### PR DESCRIPTION
It fixes the follwing error:

  /usr/bin/ld: ayatana_indicator_printers_service-indicator-printer-state-notifier.o:/workspace/ayatana-indicator-printers/src/indicator-printer-state-notifier.c:55: multiple definition of `properties'; ayatana_indicator_printers_service-indicator-printers-menu.o:/workspace/ayatana-indicator-printers/src/indicator-printers-menu.c:45: first defined here