### PR TITLE
Remove bash-ism from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,8 +50,8 @@ if test "x$CUPS_CONFIG" = "xno"; then
     AC_MSG_ERROR([could not find cups-config])
 fi
 AC_CHECK_HEADER(cups/cups.h,,AC_MSG_ERROR([could not find cups.h]))
-CUPS_CFLAGS+=`$CUPS_CONFIG --cflags`
-CUPS_LIBS+=`$CUPS_CONFIG --libs`
+CUPS_CFLAGS=`$CUPS_CONFIG --cflags`
+CUPS_LIBS=`$CUPS_CONFIG --libs`
 SERVICE_CFLAGS="$SERVICE_CFLAGS $CUPS_CFLAGS"
 SERVICE_LIBS="$SERVICE_LIBS $CUPS_LIBS"
 


### PR DESCRIPTION
The += operator is not available e.g. in busybox ash. Instead of trying
to extend CUPS_CFLAGS and _LIBS, we can just set them as nothing sets
them beforehand.