### PR TITLE
Check if valid cupsoption before processing - closes #12

### DIFF
--- a/src/indicator-printers-menu.c
+++ b/src/indicator-printers-menu.c
@@ -215,10 +215,13 @@ update_all_printer_menuitems (IndicatorPrintersMenu *self)
 
     ndests = cupsGetDests (&dests);
     for (i = 0; i < ndests; i++) {
-        int state = atoi (cupsGetOption ("printer-state",
-                                         dests[i].num_options,
-                                         dests[i].options));
-        update_printer_menuitem (self, dests[i].name, state);
+        const char *option = cupsGetOption ("printer-state",
+                                            dests[i].num_options,
+                                            dests[i].options);
+        if (option != NULL) {
+            int state = atoi (option);
+            update_printer_menuitem (self, dests[i].name, state);
+        }
     }
     cupsFreeDests (ndests, dests);
 }


### PR DESCRIPTION
From #12 - if I've read the trace correctly, its because the cups method used is returning an invalid string (null) - so this PR checks for this before further processing.

As to why the method returns a NULL - I don't really know - so maybe this is just hiding another potential issue?