### PR TITLE
.build.yml: Remove extra compilation flags

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -102,7 +102,6 @@ variables:
 #
 build_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
-  -     export CFLAGS+=" -Wsign-compare -Wunused-parameter"
   -     cppcheck --enable=warning,style,performance,portability,information,missingInclude .
   - fi
   -


### PR DESCRIPTION
We did this to all other indicators, so...